### PR TITLE
Expose raw JSON data in GlucoseReading, for serializing to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ A simple Python API to interact with Dexcom Share service. Used to get **real ti
 
 >>> bg.time
 datetime.datetime(2020, 5, 6, 18, 18, 42)
+
+>>> # Write to file: 
+>>> bg_list = dexcom.get_glucose_readings(max_count=5)
+>>> import json
+>>> with open('bg_file.json', 'w') as f:
+>>>     for bg in bg_list:
+>>>         f.write(json.dumps(bg.json)+"\n")
+
+>>> # Read from file: 
+>>> bg_list = []
+>>> from pydexcom import GlucoseReading
+>>> with open('bg_file.json', 'r') as f:
+>>>     for line in f.readlines():
+>>>         bg_list.append(GlucoseReading(json.loads(line)))
+
 ```
 
 ### FAQ
@@ -96,7 +111,7 @@ Sure, I'm thinking of implementing a session status checker, or maybe an asynchr
 | trend_description | Blood glucose trend information description (see constants). | `'steady'`                                  |
 | trend_arrow       | Blood glucose trend information as unicode arrow (see constants). | `'→'`                                  |
 | time              | Blood glucose recorded time as `datetime`.                   | `datetime.datetime(2020, 5, 6, 18, 18, 42)` |
-| json              | Blood glucose record as raw JSON, for text file output. | `{"WT": "Date(1661638198000)", "ST": "Date(1661638198000)", "DT": "Date(1661638198000-0400)", "Value": 85, "Trend": "Flat"}`
+| json              | Raw blood glucose record from Dexcom API as a dict, for JSON text file output. | `{"WT": "Date(1661638198000)", "ST": "Date(1661638198000)", "DT": "Date(1661638198000-0400)", "Value": 85, "Trend": "Flat"}`
 
 ##### Constants
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Sure, I'm thinking of implementing a session status checker, or maybe an asynchr
 | trend_description | Blood glucose trend information description (see constants). | `'steady'`                                  |
 | trend_arrow       | Blood glucose trend information as unicode arrow (see constants). | `'→'`                                  |
 | time              | Blood glucose recorded time as `datetime`.                   | `datetime.datetime(2020, 5, 6, 18, 18, 42)` |
-| json              | Raw blood glucose record from Dexcom API as a dict, for JSON text file output. | `{"WT": "Date(1661638198000)", "ST": "Date(1661638198000)", "DT": "Date(1661638198000-0400)", "Value": 85, "Trend": "Flat"}`
+| json              | Raw blood glucose record from Dexcom API as a dict, for JSON text file output. | `{"WT": "Date(1588803522000)", "Value": 85, "Trend": "Flat"}`
 
 ##### Constants
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Sure, I'm thinking of implementing a session status checker, or maybe an asynchr
 | trend_description | Blood glucose trend information description (see constants). | `'steady'`                                  |
 | trend_arrow       | Blood glucose trend information as unicode arrow (see constants). | `'→'`                                  |
 | time              | Blood glucose recorded time as `datetime`.                   | `datetime.datetime(2020, 5, 6, 18, 18, 42)` |
+| json              | Blood glucose record as raw JSON, for text file output. | `{"WT": "Date(1661638198000)", "ST": "Date(1661638198000)", "DT": "Date(1661638198000-0400)", "Value": 85, "Trend": "Flat"}`
 
 ##### Constants
 

--- a/pydexcom/__init__.py
+++ b/pydexcom/__init__.py
@@ -54,6 +54,9 @@ class GlucoseReading:
         self.time = datetime.datetime.fromtimestamp(
             int(re.sub("[^0-9]", "", json_glucose_reading["WT"])) / 1000.0
         )
+        # Drop the redundant timestamp fields
+        json_glucose_reading.pop('DT', None)
+        json_glucose_reading.pop('ST', None)
         # Allow access to raw JSON for serializing to file:
         self.json = json_glucose_reading
 

--- a/pydexcom/__init__.py
+++ b/pydexcom/__init__.py
@@ -54,6 +54,8 @@ class GlucoseReading:
         self.time = datetime.datetime.fromtimestamp(
             int(re.sub("[^0-9]", "", json_glucose_reading["WT"])) / 1000.0
         )
+        # Allow access to raw JSON for serializing to file:
+        self.json = json_glucose_reading
 
 
 class Dexcom:


### PR DESCRIPTION
For the script I'm writing, it's useful to be able to serialize the data to a file - then the readings can be cached, and each time the script runs I can reload the data and see if 5 minutes has passed since the most recent glucose reading, before fetching new data. 

This PR adds a `json` property to the `GlucoseReading` class, and provides examples in the README for how to write to and read from text files to store the data.  If you want to keep the examples in the README shorter, the examples could be dropped, but I thought it might be useful to show how to do this. 