### PR TITLE
Remove explicit timeout for the time being

### DIFF
--- a/pydexcom/__init__.py
+++ b/pydexcom/__init__.py
@@ -20,7 +20,6 @@ from .const import (
     MAX_MAX_COUNT,
     MAX_MINUTES,
     MMOL_L_CONVERSION_FACTOR,
-    REQUEST_TIMEOUT,
     TREND_ARROWS,
     TREND_DESCRIPTIONS,
 )
@@ -146,7 +145,6 @@ class Dexcom:
             headers={"Accept-Encoding": "application/json"},
             params=params,
             json={} if json is None else json,
-            timeout=REQUEST_TIMEOUT,
         )
 
         try:

--- a/pydexcom/const.py
+++ b/pydexcom/const.py
@@ -20,9 +20,6 @@ DEXCOM_AUTHENTICATE_ENDPOINT: str = "General/AuthenticatePublisherAccount"
 DEXCOM_GLUCOSE_READINGS_ENDPOINT: str = "Publisher/ReadPublisherLatestGlucoseValues"
 """Dexcom Share API endpoint used to retrieve glucose values."""
 
-REQUEST_TIMEOUT: int = 10  # seconds
-"""Standard request timeout to use when communicating with Dexcom Share API."""
-
 DEFAULT_UUID: str = "00000000-0000-0000-0000-000000000000"
 """UUID consisting of all zeros, likely error if returned by Dexcom Share API."""
 


### PR DESCRIPTION
Fixes #50.

Will re-assess whether it is useful to specify timeouts (timeouts were not specified prior to `0.3.0`), and specifically for what endpoints.