### PR TITLE
Switch account/session id in const docstring

### DIFF
--- a/pydexcom/const.py
+++ b/pydexcom/const.py
@@ -12,10 +12,10 @@ DEXCOM_BASE_URL_OUS: str = "https://shareous1.dexcom.com/ShareWebServices/Servic
 """Dexcom Share API base url for outside of the US."""
 
 DEXCOM_LOGIN_ID_ENDPOINT: str = "General/LoginPublisherAccountById"
-"""Dexcom Share API endpoint used to retrieve account ID."""
+"""Dexcom Share API endpoint used to retrieve session ID."""
 
 DEXCOM_AUTHENTICATE_ENDPOINT: str = "General/AuthenticatePublisherAccount"
-"""Dexcom Share API endpoint used to retrieve session ID."""
+"""Dexcom Share API endpoint used to retrieve account ID."""
 
 DEXCOM_GLUCOSE_READINGS_ENDPOINT: str = "Publisher/ReadPublisherLatestGlucoseValues"
 """Dexcom Share API endpoint used to retrieve glucose values."""


### PR DESCRIPTION
Just noticed `AccountId` and `SessionId` in the respective const's docstring were the wrong way round.

As an aside, I'm taking inspiration from this project to develop an ESP32 C++ implemention of your API. Here's the [project link](https://github.com/sam0jones0/SugarSentry) if you're interested.